### PR TITLE
Basic 516 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,7 +57,7 @@ checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 [[package]]
 name = "builtins-proc-macro"
 version = "0.0.0"
-source = "git+https://github.com/SpaceManiac/SpacemanDMM?rev=d6bcdd50d1532571715e24b006482094d78c1ba5#d6bcdd50d1532571715e24b006482094d78c1ba5"
+source = "git+https://github.com/SpaceManiac/SpacemanDMM?tag=suite-1.10#c1101fb3ad7971f3d19d6b81911fbd94d98fbad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -66,9 +66,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
+checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
 
 [[package]]
 name = "cfg-if"
@@ -110,9 +110,9 @@ dependencies = [
 
 [[package]]
 name = "derive-where"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2364b9aa47e460ce9bca6ac1777d14c98eef7e274eb077beed49f3adc94183ed"
+checksum = "e73f2692d4bd3cac41dca28934a39894200c9fabf49586d77d0e5954af1d7902"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -131,7 +131,7 @@ dependencies = [
 [[package]]
 name = "dreammaker"
 version = "0.1.0"
-source = "git+https://github.com/SpaceManiac/SpacemanDMM?rev=d6bcdd50d1532571715e24b006482094d78c1ba5#d6bcdd50d1532571715e24b006482094d78c1ba5"
+source = "git+https://github.com/SpaceManiac/SpacemanDMM?tag=suite-1.10#c1101fb3ad7971f3d19d6b81911fbd94d98fbad4"
 dependencies = [
  "bitflags 1.3.2",
  "builtins-proc-macro",
@@ -192,9 +192,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 
 [[package]]
 name = "indexmap"
@@ -215,7 +215,7 @@ checksum = "71dd52191aae121e8611f1e8dc3e324dd0dd1dee1e6dd91d10ee07a3cfb4d9d8"
 [[package]]
 name = "interval-tree"
 version = "0.8.0"
-source = "git+https://github.com/SpaceManiac/SpacemanDMM?rev=d6bcdd50d1532571715e24b006482094d78c1ba5#d6bcdd50d1532571715e24b006482094d78c1ba5"
+source = "git+https://github.com/SpaceManiac/SpacemanDMM?tag=suite-1.10#c1101fb3ad7971f3d19d6b81911fbd94d98fbad4"
 
 [[package]]
 name = "libc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,19 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
-name = "ahash"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
-dependencies = [
- "cfg-if",
- "getrandom",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "attribute-derive"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -30,7 +17,7 @@ dependencies = [
  "attribute-derive-macro",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -46,7 +33,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "quote-use",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -63,14 +50,14 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "builtins-proc-macro"
 version = "0.0.0"
-source = "git+https://github.com/SpaceManiac/SpacemanDMM?tag=suite-1.9#181067efd1e939e9ca83e71460a95a39a4cb3156"
+source = "git+https://github.com/SpaceManiac/SpacemanDMM?rev=d6bcdd50d1532571715e24b006482094d78c1ba5#d6bcdd50d1532571715e24b006482094d78c1ba5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -79,9 +66,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.21.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
+checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
 
 [[package]]
 name = "cfg-if"
@@ -123,20 +110,20 @@ dependencies = [
 
 [[package]]
 name = "derive-where"
-version = "1.2.7"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62d671cc41a825ebabc75757b62d3d168c577f9149b2d49ece1dad1f72119d25"
+checksum = "2364b9aa47e460ce9bca6ac1777d14c98eef7e274eb077beed49f3adc94183ed"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "dmasm"
 version = "0.1.0"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "dreammaker",
  "nom",
 ]
@@ -144,13 +131,13 @@ dependencies = [
 [[package]]
 name = "dreammaker"
 version = "0.1.0"
-source = "git+https://github.com/SpaceManiac/SpacemanDMM?tag=suite-1.9#181067efd1e939e9ca83e71460a95a39a4cb3156"
+source = "git+https://github.com/SpaceManiac/SpacemanDMM?rev=d6bcdd50d1532571715e24b006482094d78c1ba5#d6bcdd50d1532571715e24b006482094d78c1ba5"
 dependencies = [
- "ahash",
  "bitflags 1.3.2",
  "builtins-proc-macro",
  "color_space",
  "derivative",
+ "foldhash",
  "get-size",
  "get-size-derive",
  "indexmap",
@@ -165,14 +152,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "flate2"
-version = "1.0.35"
+name = "equivalent"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "flate2"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "get-size"
@@ -188,33 +187,22 @@ checksum = "13a1bcfb855c1f340d5913ab542e36f25a1c56f57de79022928297632435dec2"
 dependencies = [
  "attribute-derive",
  "quote",
- "syn 2.0.98",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
- "autocfg",
+ "equivalent",
  "hashbrown",
 ]
 
@@ -227,13 +215,13 @@ checksum = "71dd52191aae121e8611f1e8dc3e324dd0dd1dee1e6dd91d10ee07a3cfb4d9d8"
 [[package]]
 name = "interval-tree"
 version = "0.8.0"
-source = "git+https://github.com/SpaceManiac/SpacemanDMM?tag=suite-1.9#181067efd1e939e9ca83e71460a95a39a4cb3156"
+source = "git+https://github.com/SpaceManiac/SpacemanDMM?rev=d6bcdd50d1532571715e24b006482094d78c1ba5#d6bcdd50d1532571715e24b006482094d78c1ba5"
 
 [[package]]
 name = "libc"
-version = "0.2.170"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "lodepng"
@@ -261,9 +249,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.5"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
 ]
@@ -286,12 +274,6 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
-
-[[package]]
-name = "once_cell"
-version = "1.20.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
 name = "ordered-float"
@@ -332,7 +314,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -381,18 +363,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -405,7 +387,7 @@ checksum = "a7b5abe3fe82fdeeb93f44d66a7b444dedf2e4827defb0a8e69c437b2de2ef94"
 dependencies = [
  "quote",
  "quote-use-macros",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -417,7 +399,7 @@ dependencies = [
  "derive-where",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -446,22 +428,22 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.218"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.218"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -472,9 +454,9 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "smallvec"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "syn"
@@ -489,9 +471,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.98"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -518,21 +500,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "winapi-util"
@@ -615,23 +591,3 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.98",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ repository = "https://github.com/willox/dmasm"
 [dependencies]
 nom = "7"
 bitflags = "2"
-dreammaker = { git = "https://github.com/SpaceManiac/SpacemanDMM", tag = "suite-1.9" }
+dreammaker = { git = "https://github.com/SpaceManiac/SpacemanDMM", rev = "d6bcdd50d1532571715e24b006482094d78c1ba5" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ repository = "https://github.com/willox/dmasm"
 [dependencies]
 nom = "7"
 bitflags = "2"
-dreammaker = { git = "https://github.com/SpaceManiac/SpacemanDMM", rev = "d6bcdd50d1532571715e24b006482094d78c1ba5" }
+dreammaker = { git = "https://github.com/SpaceManiac/SpacemanDMM", tag = "suite-1.10" }

--- a/src/compiler/binary_ops.rs
+++ b/src/compiler/binary_ops.rs
@@ -48,6 +48,7 @@ pub(super) fn emit(
         | BinaryOp::LessEq
         | BinaryOp::Greater
         | BinaryOp::GreaterEq
+        | BinaryOp::LessOrGreater
         | BinaryOp::Equiv
         | BinaryOp::NotEquiv
         | BinaryOp::BitAnd
@@ -81,6 +82,7 @@ pub(super) fn emit(
                 BinaryOp::LessEq => compiler.emit_ins(Instruction::Tle),
                 BinaryOp::Greater => compiler.emit_ins(Instruction::Tg),
                 BinaryOp::GreaterEq => compiler.emit_ins(Instruction::Tge),
+                BinaryOp::LessOrGreater => compiler.emit_ins(Instruction::Tlog),
                 BinaryOp::Equiv => compiler.emit_ins(Instruction::TestEquiv),
                 BinaryOp::NotEquiv => compiler.emit_ins(Instruction::TestNotEquiv),
                 BinaryOp::BitAnd => compiler.emit_ins(Instruction::Band),

--- a/src/compiler/binary_ops.rs
+++ b/src/compiler/binary_ops.rs
@@ -82,7 +82,7 @@ pub(super) fn emit(
                 BinaryOp::LessEq => compiler.emit_ins(Instruction::Tle),
                 BinaryOp::Greater => compiler.emit_ins(Instruction::Tg),
                 BinaryOp::GreaterEq => compiler.emit_ins(Instruction::Tge),
-                BinaryOp::LessOrGreater => compiler.emit_ins(Instruction::Tlog),
+                BinaryOp::LessOrGreater => compiler.emit_ins(Instruction::Spaceship),
                 BinaryOp::Equiv => compiler.emit_ins(Instruction::TestEquiv),
                 BinaryOp::NotEquiv => compiler.emit_ins(Instruction::TestNotEquiv),
                 BinaryOp::BitAnd => compiler.emit_ins(Instruction::Band),

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -516,7 +516,7 @@ instructions! {
     // 0x17b
     0x17c = NewAlist,
     0x17d = Spaceship, // <=> (less or greater) comparator. It looks like a spaceship, and thus will be called "Spaceship", because "Tlog" is a dumb instruction name, and we all need some whimsy in our lives.
-    0x17e = KeyValueIter, // for (k,v in list)
+    0x17e = KeyValueIter(var: Variable), // for (k,v in list)
     0x17f = NewPixloc,
     0x180 = NewVector,
     0x181 = BoundPixloc,
@@ -534,8 +534,6 @@ instructions! {
 
     0x1337 = AuxtoolsDebugBreak,
     0x1338 = AuxtoolsDebugBreakNop,
-
-    0xffce = GeneratorNew, // ????
 }
 
 impl std::fmt::Display for Instruction {

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -511,9 +511,31 @@ instructions! {
     0x176 = FloatMod,
     0x177 = AugFloatMod(var: Variable),
     0x178 = RefCount,
+    0x179 = LoadExt,
+    0x17a = CallExtLoaded, // single-arg call_ext, for when you just pass the return value of load_ext to it
+    // 0x17b
+    0x17c = NewAlist,
+    0x17d = Tlog, // <=> (less or greater) comparator
+    0x17e = KeyValueIter, // for (k,v in list)
+    0x17f = NewPixloc,
+    // 0x180
+    0x181 = BoundPixloc,
+    // 0x182
+    // 0x183
+    // 0x184
+    0x185 = AsType,
+    0x186 = Sign,
+    0x187 = Lerp,
+    0x188 = ValuesSum,
+    0x189 = ValuesProduct,
+    0x18a = ValuesDot,
+    0x18b = ValuesCutUnder,
+    0x18c = ValuesCutOver,
 
     0x1337 = AuxtoolsDebugBreak,
     0x1338 = AuxtoolsDebugBreakNop,
+
+    0xffce = GeneratorNew, // ????
 }
 
 impl std::fmt::Display for Instruction {

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -484,7 +484,7 @@ instructions! {
     0x15B = PushCacheKey,
     0x15C = PopCacheKey,
     0x15D = Time2TextTZ(arg_count: u32),
-    0x15E = MakeGenerator,
+    0x15E = MakeGenerator(unk0: u32),
     0x15F = SpliceText,
     0x160 = SpliceTextChar,
     0x161 = RgbEx, // Used when the color space for rgb() cannot be found to be COLORSPACE_RGB at compile-time

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -515,7 +515,7 @@ instructions! {
     0x17a = CallExtLoaded, // single-arg call_ext, for when you just pass the return value of load_ext to it
     // 0x17b
     0x17c = NewAlist,
-    0x17d = Tlog, // <=> (less or greater) comparator
+    0x17d = Spaceship, // <=> (less or greater) comparator. It looks like a spaceship, and thus will be called "Spaceship", because "Tlog" is a dumb instruction name, and we all need some whimsy in our lives.
     0x17e = KeyValueIter, // for (k,v in list)
     0x17f = NewPixloc,
     0x180 = NewVector,

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -518,7 +518,7 @@ instructions! {
     0x17d = Tlog, // <=> (less or greater) comparator
     0x17e = KeyValueIter, // for (k,v in list)
     0x17f = NewPixloc,
-    // 0x180
+    0x180 = NewVector,
     0x181 = BoundPixloc,
     // 0x182
     // 0x183


### PR DESCRIPTION
- updated the `dreammaker` dependency to `suite-1.10`
  - ~~however, due to the lack of a full release with 516 support, I've just pinned it to the `d6bcdd50d1532571715e24b006482094d78c1ba5` commit (latest master at the time of submitting this PR) - I'll change it to the next release's tag whenever it gets published~~
- added the new 516 instructions I've found (`0x179` through `0x18c`, although `0x17b`, `0x182`, `0x183`, and `0x184` are still unknown)
- also fixed the `MakeGenerator` instruction

just for reference, my findings (using [auxdismdump](https://github.com/Absolucy/auxdismdump)):
> `0x179`: load_ext
> `0x17a`: call_ext(LoadedFunc)
> `0x17c`: alist
> `0x17d`: `<=>` comparator
> `0x17e`: `for(k,v in list)`
> `0x17f`: pixloc()
> `0x180`: vector()
> `0x181`: bound_pixloc
> `0x185`: astype
> `0x186`: sign
> `0x187`: lerp
> `0x188`: values_sum
> `0x189`: values_product
> `0x18a`: values_dot
> `0x18b`: values_cut_under
> `0x18c`: values_cut_over