### PR TITLE
better debug impl for DMString

### DIFF
--- a/src/operands.rs
+++ b/src/operands.rs
@@ -149,12 +149,18 @@ impl Operand for Proc {
 //
 // DMString
 //
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Clone)]
 pub struct DMString(pub Vec<u8>);
 
 impl DMString {
     fn get_string_index<E: AssembleEnv>(&self, asm: &mut Assembler<E>) -> u32 {
         asm.env.get_string_index(&self.0).unwrap()
+    }
+}
+
+impl fmt::Debug for DMString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.serialize(f)
     }
 }
 


### PR DESCRIPTION
manually impls `Debug` for `DMString`, so that it will render the actual string (we already have `DMString::serialize` lmao) instead of just the string bytes